### PR TITLE
Galactic uses foxy-devel branch

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -88,7 +88,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
-    devel_branch: master
+    devel_branch: foxy-devel
     last_version: 2.3.0
     name: upstream
     patches: null


### PR DESCRIPTION
This undoes 2f9a6d016728fe96cfa7bd05f55a4ff0fa16ce0d so that Galactic is released from the `foxy-devel` branch. It might have been accidentally changed https://github.com/ros-controls/realtime_tools/pull/87#issuecomment-1275063268